### PR TITLE
Added missing functions in expansion

### DIFF
--- a/bsc.cpp
+++ b/bsc.cpp
@@ -58,15 +58,21 @@ EMail:              geom@cs.unc.edu; tang_m@zju.edu.cn
 #pragma warning(disable: 4996)
 #include "rootparitycollisiontest.h"
 #include <cstdlib>
+#include <cfloat>
 
-namespace rootparity 
+namespace rootparity
 {
-    
+
     namespace   // unnamed namespace for local functions
     {
 		template<unsigned int N, class T>
-		inline void make_vector( const Vec<N,double>& in, Vec<N,T>& out );
-        
+		inline void make_vector( const Vec<N,double>& in, Vec<N,T>& out )
+        {
+            for(int i = 0; i < N; i++){
+                out[i] = T(in[i]);
+            }
+        }
+
 		//					| a  b |
 		//  return		| c  d | = a*d - b*c
 		template <class T>
@@ -79,7 +85,7 @@ namespace rootparity
 		template <class T>
 		inline bool bezierDecomposition(const T &k0, const T &k1, const T &k2, const T &k3,
 							const T &j0, const T &j1, const T &j2,
-							T &m0, T &m1, 
+							T &m0, T &m1,
 							T &n0, T &n1)
 		{
 			T A = (j1-j2)*T(2.0);
@@ -88,7 +94,7 @@ namespace rootparity
 			T D = k1*T(3.0) - k0*T(2.0) -k3;
 			T E = j2-j0;
 			T F = (j1-j0)*T(2.0);
-			
+
 			T tt = det2x2(A, B, E, F);
 			 if ( tt.is_certainly_zero() ) {
 				printf("@@@det = 0.\n");
@@ -249,7 +255,7 @@ namespace rootparity
 			double p3 = B;
 
 			double e1, e2; // conservative bounds, can be calculated on the fly
-			
+
 			e1 = DBL_EPSILON*100;
 			e2 = DBL_EPSILON*100;
 
@@ -416,7 +422,7 @@ namespace rootparity
 
 				if ((c.kk0+c.kk2-c.kk1*T(2.0)).is_certainly_zero()) {
 					printf("@@@degenerated ...\n");
-					
+
 					//T t = lineRoot(c.kk0, c.kk2);
 					//T fk = evaluateBezier(c.k0, c.k1, c.k2, c.k3, t);
 					T fk = _evaluateBezier(c.k0, c.k1, c.k2, c.k3, c.kk0, -c.kk2);
@@ -506,8 +512,8 @@ namespace rootparity
 				lt0 = t0;
 				lt1 = t0;
 				return true;
-			} 
-			
+			}
+
 			if ((c.ct == 0) ||
 				(c.ct == 1 && diffSign(c.k0, c.k3))) {
 				//T t = lineRoot(t0, t1);
@@ -526,7 +532,7 @@ namespace rootparity
 				}
 				return true;
 			}
-			
+
 			if (c.ct == 1) {
 //				T t = lineRoot(t0, t1);
 //				T ft = evaluateBezier(c.k0, c.k1, c.k2, c.k3, t);
@@ -599,7 +605,7 @@ namespace rootparity
 					}
 
 					continue;
-				} 
+				}
 
 				if (false == bezierDecomposition(c.k0, c.k1, c.k2, c.k3, j0, j1, j2, s0, s1, t0, t1)) {
 					getSigns(j0, j2, c, lt0, lt1);
@@ -634,11 +640,11 @@ namespace rootparity
 					continue;
 				}
 
-				// kill an possiblity 
+				// kill an possiblity
 				if (sameSign(lt0, kt0))
 					bt0 = false;
 
-				// kill an possiblity 
+				// kill an possiblity
 				if (sameSign(lt1, kt1))
 					bt1 = false;
 
@@ -676,23 +682,27 @@ namespace rootparity
 				Vec<3, T> bt = b0*(T(1.0)-t)+b1*t;
 				Vec<3, T> ct = c0*(T(1.0)-t)+c1*t;
 				Vec<3, T> dt = d0*(T(1.0)-t)+d1*t;
-			
+
 				bool ret1 = Intersect_robust(a0, b0, c0, d0, at, bt, ct, dt, ee_test);
 				bool ret2 = Intersect_robust(at, bt, ct, dt, a1, b1, c1, d1, ee_test);
 
+                T::end_special_arithmetic();
 				return ret1 || ret2;
 			}
 
 			bcrv<T> c(k0, k1, k2, k3, kk0, kk1, kk2, ct);
 
 			if (!coplanarTest(c)) {
+                T::end_special_arithmetic();
 				return false;
 			}
 
 			if (!insideTest(a0, b0, c0, d0, a1, b1, c1, d1, c, ee_test)) {
+                T::end_special_arithmetic();
 				return false;
 			}
 
+            T::end_special_arithmetic();
 			return true;
 		}
 
@@ -767,5 +777,5 @@ namespace rootparity
 
 			return ret;
 		}
-	} 
-}  // namespace rootparity 
+	}
+}  // namespace rootparity

--- a/expansion.cpp
+++ b/expansion.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 
 namespace {
-   
+
 //==============================================================================
 void
 two_sum(double a,
@@ -72,11 +72,11 @@ is_zero( const expansion& a )
 
 
 //==============================================================================
-int 
+int
 sign( const expansion& a )
 {
    if ( a.v.size() == 0 ) { return 0; }
-   
+
    // REVIEW: I'm assuming we can get the sign of the expansion by the sign of its leading term (i.e. the sum of all other terms < leading term )
    // This true if the expansion if increasing and nonoverlapping
    if ( a.v.back() > 0 )
@@ -115,7 +115,7 @@ add(const expansion& a, double b, expansion& sum)
 void
 add(const expansion& a, const expansion& b, expansion& sum)
 {
-   
+
    if(a.v.empty())
    {
       sum=b;
@@ -125,7 +125,7 @@ add(const expansion& a, const expansion& b, expansion& sum)
       sum=a;
       return;
    }
-      
+
    // Shewchuk's fast-expansion-sum
    expansion merge(a.v.size()+b.v.size(), 0);
    unsigned int i=0, j=0, k=0;
@@ -150,7 +150,7 @@ add(const expansion& a, const expansion& b, expansion& sum)
    fast_two_sum(merge.v[1], merge.v[0], q, r);
    if(r) sum.v.push_back(r);
    for(i=2; i<merge.v.size(); ++i){
-      two_sum(q, merge.v[i], q, r);    
+      two_sum(q, merge.v[i], q, r);
       if(r) sum.v.push_back(r);
    }
    if(q) sum.v.push_back(q);
@@ -232,8 +232,8 @@ multiply(const expansion& a, double b, expansion& product)
    // multiplication is a prime candidate for producing spurious zeros, so
    // remove them by default
    remove_zeros(product);
-   
-} 
+
+}
 
 //==============================================================================
 void
@@ -262,10 +262,10 @@ void compress( const expansion& e, expansion& h )
    }
 
    expansion g( e.v.size(), 0 );
-   
+
    size_t bottom = e.v.size() - 1;
    double q = e.v[bottom];
-   
+
    for ( ssize_t i = e.v.size() - 2; i >= 0; --i )
    {
       double new_q, small_q;
@@ -281,7 +281,7 @@ void compress( const expansion& e, expansion& h )
       }
    }
    g.v[bottom] = q;
-   
+
    h.v.resize( e.v.size(), 0 );
 
    unsigned int top = 0;
@@ -298,7 +298,7 @@ void compress( const expansion& e, expansion& h )
    }
    h.v[top] = q;
    h.resize( top+1 );
-         
+
 }
 
 
@@ -306,27 +306,27 @@ void compress( const expansion& e, expansion& h )
 
 bool divide( const expansion& x, const expansion& y, expansion& q )
 {
-   
+
    assert( !is_zero( y ) );
-   
-   if ( is_zero( x ) ) 
+
+   if ( is_zero( x ) )
    {
       // 0 / y = 0
       make_expansion( 0, q );
       return true;
    }
-   
+
    const double divisor = estimate(y);
-   
+
    // q is the quotient, built by repeatedly dividing the remainder
    // Initially, q = estimate(x) / estimate(y)
-   
+
    make_expansion( estimate(x) / divisor, q );
 
    expansion qy;
    multiply( q, y, qy );
    expansion r;
-   subtract( x, qy, r );  
+   subtract( x, qy, r );
 
    while ( !is_zero(r) )
    {
@@ -340,16 +340,16 @@ bool divide( const expansion& x, const expansion& y, expansion& q )
          assert ( !is_zero(y) );
          std::cout << "underflow, s == 0" << std::endl;
          std::cout << "divisor: " << divisor << std::endl;
-         return false;         
+         return false;
       }
-         
+
       // q += s
       add( q, s, q );
 
       // r -= s*y
       expansion sy;
       multiply( s, y, sy );
-      
+
       // underflow, quotient not representable by an expansion
       if ( is_zero(sy) )
       {
@@ -357,27 +357,27 @@ bool divide( const expansion& x, const expansion& y, expansion& q )
          std::cout << "underflow, sy == 0" << std::endl;
          return false;
       }
-      
-      subtract( r, sy, r );     
-      
+
+      subtract( r, sy, r );
+
       expansion compressed_r;
       compress( r, compressed_r );
       r = compressed_r;
-      
+
    }
-   
+
    remove_zeros( q );
    return true;
-   
+
 }
 
 //==============================================================================
 void
 remove_zeros(expansion& a)
 {
-   
+
    unsigned int i, j;
-   
+
    for ( i = 0, j = 0; i < a.v.size(); ++i )
    {
       if ( a.v[i] )
@@ -385,9 +385,9 @@ remove_zeros(expansion& a)
          a.v[j++] = a.v[i];
       }
    }
-   
+
    a.resize(j);
-   
+
 }
 
 //==============================================================================
@@ -405,35 +405,31 @@ estimate(const expansion& a)
 bool equals( const expansion& a, const expansion& b )
 {
    bool same = (a.v.size() == b.v.size());
-   
+
    if (!same) { return false; }
-   
+
    for ( unsigned int i = 0; i < a.v.size(); ++i )
    {
       same &= (a.v[i] == b.v[i]);
    }
-   
+
    return same;
-   
+
 }
 
 //==============================================================================
 
 void print_full( const expansion& e )
 {
-   if ( e.v.size() == 0 ) 
-   { 
+   if ( e.v.size() == 0 )
+   {
       std::cout << "0" << std::endl;
-      return; 
+      return;
    }
-   
+
    for ( unsigned int j = 0; j < e.v.size(); ++j )
    {
       std::cout << e.v[j] << " ";
    }
-   std::cout << std::endl;   
+   std::cout << std::endl;
 }
-
-
-
-

--- a/expansion.h
+++ b/expansion.h
@@ -8,7 +8,7 @@
 
 #include <vector>
 
-// The basic type is essentially a vector of *increasing* and 
+// The basic type is essentially a vector of *increasing* and
 // *nonoverlapping* doubles, apart from allowed zeroes anywhere.
 
 class expansion;
@@ -87,9 +87,9 @@ print_full( const expansion& e );
 
 class expansion
 {
-      
+
 public:
-   
+
    std::vector<double> v;
 
    expansion()
@@ -99,25 +99,25 @@ public:
    explicit expansion( double val )
     : v(1, val)
    {}
-   
+
    expansion( std::size_t n, double val )
    : v(n,val)
    {}
-   
+
    virtual ~expansion() {}
-   
+
    expansion& operator+=(const expansion &rhs)
    {
       add( *this, rhs, *this );
       return *this;
    }
-   
+
    expansion& operator-=(const expansion &rhs)
    {
       subtract( *this, rhs, *this );
       return *this;
    }
-   
+
    expansion& operator*=(const expansion &rhs)
    {
       expansion p;
@@ -125,52 +125,68 @@ public:
       *this = p;
       return *this;
    }
-   
-   inline expansion operator+(const expansion &other) const 
+
+   inline expansion operator+(const expansion &other) const
    {
-      expansion result = *this;     
-      result += other;  
-      return result;              
+      expansion result = *this;
+      result += other;
+      return result;
    }
-   
-   inline expansion operator-(const expansion &other) const 
+
+   inline expansion operator-(const expansion &other) const
    {
-      expansion result = *this;    
-      result -= other;  
-      return result;              
+      expansion result = *this;
+      result -= other;
+      return result;
    }
-   
-   
+
+
    inline expansion operator*(const expansion &other) const
    {
-      expansion result = *this;    
-      result *= other;  
-      return result;              
+      expansion result = *this;
+      result *= other;
+      return result;
    }
-   
+
    inline expansion operator-( ) const
    {
       expansion result;
       negative( *this, result );
       return result;
    }
-   
+
+   bool is_certainly_negative() const{
+       return sign(*this) < 0;
+   }
+
+   bool is_certainly_positive() const{
+       return sign(*this) > 0;
+   }
+
+   bool is_certainly_zero() const{
+       return is_zero(*this);
+   }
+
+   bool same_sign(const expansion& b) const{
+       return sign(*this) == sign(b);
+   }
+
    inline double estimate() const
    {
       return ::estimate( *this );
    }
-   
+
    inline bool indefinite_sign() const
    {
       return false;
    }
-   
+
    static void begin_special_arithmetic()
    {}
-   
+
    static void end_special_arithmetic()
    {}
-   
+
    inline void clear()
    {
       v.clear();
@@ -185,10 +201,10 @@ public:
 
 
 inline void make_expansion( double a, expansion& e )
-{ 
-   if(a) 
+{
+   if(a)
    {
-      e = expansion(1, a); 
+      e = expansion(1, a);
    }
    else
    {


### PR DESCRIPTION
1. The code made use of `expansion::is_certainly_zero`, `expansion::is_certainly_negative`  etc., I implemented these.
2. Implemented the make_vector function in `bsc.cpp`
    ```
    template<unsigned int N, class T>
    inline void make_vector(const Vec<N,double>& in, Vec<N,T>& out );
    ```
3. inside bool Intersect_robust, properly set `T::end_special_arithmetic();` for all branches.

TODO:
Some corner cases are not considered, for example, a trivial case as
follows would fail (after fixing the aforementioned issues), testing a
fixed point at the origin against a moving triangle, initially
vertex-touching the origin
```
    Vec3d q(0,0,0);
    Vec3d b0(0,0,0);
    Vec3d b1(0,1,0);
    Vec3d b2(1,0,0);

    Vec3d t0(0,0,1);
    Vec3d t1(0,1,1);
    Vec3d t2(1,0,1);

    Vec3d q1(0,0,0);
    CHECK(rootparity::Intersect_VF_robust(
        b0, b1, b2, q, t0, t1, t2, q1));
```